### PR TITLE
Separate split_ratio on each space

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -131,10 +131,8 @@ static struct Space *prev_space(struct Space *space, bool (*filter)(struct Space
 
 static void change_split_ratio(struct Space *space, float change) {
 	float target = space->tiled_splitratio + change;
-	if (target < 0.1)
-		target = 0.1;
-	if (target > 0.9)
-		target = 0.9;
+	if (target < 0.1 || target > 0.9)
+		return;
 	space->tiled_splitratio = target;
 }
 
@@ -194,11 +192,8 @@ extern void binding_toggle_monocle(struct Seat *seat, union Arg arg) {
 		space->layout = default_layout;
 }
 
-extern void binding_increase_split_ratio(struct Seat *seat, union Arg arg) {
-	change_split_ratio(seat->focused, 0.1);
-}
-extern void binding_decrease_split_ratio(struct Seat *seat, union Arg arg) {
-	change_split_ratio(seat->focused, -0.1);
+extern void binding_change_split_ratio(struct Seat *seat, union Arg arg) {
+	change_split_ratio(seat->focused, arg.f);
 }
 
 extern void binding_focus_next(struct Seat *seat, union Arg arg) {

--- a/bindings.c
+++ b/bindings.c
@@ -129,6 +129,15 @@ static struct Space *prev_space(struct Space *space, bool (*filter)(struct Space
 	return NULL;
 }
 
+static void change_split_ratio(struct Space *space, float change) {
+	float target = space->tiled_splitratio + change;
+	if (target < 0.1)
+		target = 0.1;
+	if (target > 0.9)
+		target = 0.9;
+	space->tiled_splitratio = target;
+}
+
 
 // Binding function definitions
 // None of these functions run during a manage or render sequence
@@ -183,6 +192,13 @@ extern void binding_toggle_monocle(struct Seat *seat, union Arg arg) {
 		space->layout = monocle_layout;
 	else
 		space->layout = default_layout;
+}
+
+extern void binding_increase_split_ratio(struct Seat *seat, union Arg arg) {
+	change_split_ratio(seat->focused, 0.1);
+}
+extern void binding_decrease_split_ratio(struct Seat *seat, union Arg arg) {
+	change_split_ratio(seat->focused, -0.1);
 }
 
 extern void binding_focus_next(struct Seat *seat, union Arg arg) {

--- a/config.c
+++ b/config.c
@@ -80,8 +80,8 @@ struct Binddef binds[] = {
 	{super|shift, XKB_KEY_j, binding_move_next,  {0}},
 	{super,       XKB_KEY_k, binding_focus_prev, {0}},
 	{super|shift, XKB_KEY_k, binding_move_prev,  {0}},
-	{super|alt,   XKB_KEY_h, binding_decrease_split_ratio, {0}},
-	{super|alt,   XKB_KEY_l, binding_increase_split_ratio, {0}},
+	{super|alt,   XKB_KEY_h, binding_change_split_ratio, {.f = -0.1}},
+	{super|alt,   XKB_KEY_l, binding_change_split_ratio, {.f =  0.1}},
 
 	// Bindings for relative motion between spaces
 	{super,       XKB_KEY_h, binding_activate_prev_busy_space, {0}},

--- a/config.c
+++ b/config.c
@@ -80,6 +80,8 @@ struct Binddef binds[] = {
 	{super|shift, XKB_KEY_j, binding_move_next,  {0}},
 	{super,       XKB_KEY_k, binding_focus_prev, {0}},
 	{super|shift, XKB_KEY_k, binding_move_prev,  {0}},
+	{super|alt,   XKB_KEY_h, binding_decrease_split_ratio, {0}},
+	{super|alt,   XKB_KEY_l, binding_increase_split_ratio, {0}},
 
 	// Bindings for relative motion between spaces
 	{super,       XKB_KEY_h, binding_activate_prev_busy_space, {0}},

--- a/jrwm.c
+++ b/jrwm.c
@@ -86,6 +86,7 @@ extern struct Output *active_on_output(struct Space *space) {
 extern struct Space *create_space(void) {
 	struct Space *space = calloc(1, sizeof(struct Space));
 	space->layout = default_layout;
+	space->tiled_splitratio = tiled_splitratio;
 	return space;
 }
 

--- a/jrwm.h
+++ b/jrwm.h
@@ -40,6 +40,7 @@ struct Space {
 	struct Window *focused; // May be null
 
 	bool is_static;         // Static spaces are never removed
+	float tiled_splitratio;
 
 	void (*layout)(struct Space *space, struct Rect bounds);
 };
@@ -164,6 +165,9 @@ extern void binding_close(struct Seat *, union Arg);
 extern void binding_toggle_fake_fullscreen(struct Seat *, union Arg);
 extern void binding_toggle_fullscreen(struct Seat *, union Arg);
 extern void binding_toggle_monocle(struct Seat *, union Arg);
+
+extern void binding_increase_split_ratio(struct Seat *, union Arg);
+extern void binding_decrease_split_ratio(struct Seat *, union Arg);
 
 extern void binding_focus_next(struct Seat *, union Arg);
 extern void binding_focus_prev(struct Seat *, union Arg);

--- a/jrwm.h
+++ b/jrwm.h
@@ -98,6 +98,7 @@ struct Seat {
 union Arg {
 	char **v;
 	int32_t i;
+	float f;
 };
 
 struct Binddef {
@@ -166,8 +167,7 @@ extern void binding_toggle_fake_fullscreen(struct Seat *, union Arg);
 extern void binding_toggle_fullscreen(struct Seat *, union Arg);
 extern void binding_toggle_monocle(struct Seat *, union Arg);
 
-extern void binding_increase_split_ratio(struct Seat *, union Arg);
-extern void binding_decrease_split_ratio(struct Seat *, union Arg);
+extern void binding_change_split_ratio(struct Seat *, union Arg);
 
 extern void binding_focus_next(struct Seat *, union Arg);
 extern void binding_focus_prev(struct Seat *, union Arg);

--- a/layout.c
+++ b/layout.c
@@ -192,7 +192,7 @@ extern void tiled_layout(struct Space *space, struct Rect bounds) {
 			// Left side "main" window
 			window->layout = bounds;
 			if (count > 1)
-				window->layout.width *= tiled_splitratio;
+				window->layout.width *= space->tiled_splitratio;
 
 			rightwidth -= window->layout.width + tiled_margin;
 		} else {


### PR DESCRIPTION
Add binds for changing split_ratio on each space independently.

One issue with this is that if you hit a limit, you can no longer set to the default which is 0.52, not sure if it's worth adding a reset bind for that edge case though?