### PR TITLE
Add floating windows

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -184,6 +184,13 @@ extern void binding_toggle_fullscreen(struct Seat *seat, union Arg arg) {
 		window->enter_fullscreen = true;
 }
 
+extern void binding_toggle_floating(struct Seat *seat, union Arg arg) {
+	struct Window *window = seat->focused->focused;
+	if (window == NULL)
+		return;
+	window->floating = !window->floating;
+}
+
 extern void binding_toggle_monocle(struct Seat *seat, union Arg arg) {
 	struct Space *space = seat->focused;
 	if (space->layout != monocle_layout)

--- a/config.c
+++ b/config.c
@@ -72,6 +72,7 @@ struct Binddef binds[] = {
 	{super,       XKB_KEY_q, binding_close,                  {0}},
 	{super|shift, XKB_KEY_e, binding_exit,                   {0}},
 	{super,       XKB_KEY_m, binding_toggle_monocle,         {0}},
+	{super,       XKB_KEY_f, binding_toggle_floating,        {0}},
 	{super|shift, XKB_KEY_f, binding_toggle_fullscreen,      {0}},
 	{super|shift, XKB_KEY_m, binding_toggle_fake_fullscreen, {0}},
 

--- a/jrwm.c
+++ b/jrwm.c
@@ -202,6 +202,16 @@ static void window_handle_unmaximize_requested(void *data, struct river_window_v
 		window->space->layout = tiled_layout;
 }
 
+static void window_handle_pointer_move_requested(void *data, struct river_window_v1 *obj, struct river_seat_v1 *river_seat) {
+	struct Window *window = data;
+	window->pointer_move_requested = river_seat_v1_get_user_data(river_seat);
+}
+static void window_handle_pointer_resize_requested(void *data, struct river_window_v1 *obj, struct river_seat_v1 *river_seat, uint32_t edges) {
+	struct Window *window = data;
+	window->pointer_resize_requested = river_seat_v1_get_user_data(river_seat);
+	window->pointer_resize_requested_edges = edges;
+}
+
 // Ignored events
 static void window_handle_app_id(void *data, struct river_window_v1 *obj, const char *app_id) {}
 static void window_handle_decoration_hint(void *data, struct river_window_v1 *obj, uint32_t hint) {}
@@ -209,8 +219,6 @@ static void window_handle_dimensions_hint(void *data, struct river_window_v1 *ob
 static void window_handle_identifier(void *data, struct river_window_v1 *obj, const char *indentifier) {}
 static void window_handle_minimize_requested(void *data, struct river_window_v1 *obj) {}
 static void window_handle_parent(void *data, struct river_window_v1 *obj, struct river_window_v1 *parent) {}
-static void window_handle_pointer_move_requested(void *data, struct river_window_v1 *obj, struct river_seat_v1 *river_seat) {}
-static void window_handle_pointer_resize_requested(void *data, struct river_window_v1 *obj, struct river_seat_v1 *river_seat, uint32_t edges) {}
 static void window_handle_presentation_hint(void *data, struct river_window_v1 *obj, uint32_t hint) {}
 static void window_handle_show_window_menu_requested(void *data, struct river_window_v1 *obj, int32_t x, int32_t y) {}
 static void window_handle_title(void *data, struct river_window_v1 *obj, const char *title) {}
@@ -278,8 +286,17 @@ static void seat_handle_pointer_position(void *data, struct river_seat_v1 *obj, 
 		seat->focused = output->active;
 }
 
-static void seat_handle_op_delta(void *data, struct river_seat_v1 *obj, int32_t dx, int32_t dy) {}
-static void seat_handle_op_release(void *data, struct river_seat_v1 *obj) {}
+static void seat_handle_op_delta(void *data, struct river_seat_v1 *obj, int32_t dx, int32_t dy) {
+	struct Seat *seat = data;
+	seat->op_dx = dx;
+	seat->op_dy = dy;
+
+}
+static void seat_handle_op_release(void *data, struct river_seat_v1 *obj) {
+	struct Seat *seat = data;
+	seat->op_release = true;
+}
+
 static void seat_handle_pointer_leave(void *data, struct river_seat_v1 *obj) {}
 static void seat_handle_shell_surface_interaction(void *data, struct river_seat_v1 *obj, struct river_shell_surface_v1 *river_shell_surface) {}
 static void seat_handle_wl_seat(void *data, struct river_seat_v1 *obj, uint32_t id) {}
@@ -342,12 +359,62 @@ static void wm_handle_seat(void *data, struct river_window_manager_v1 *obj, stru
 	river_layer_shell_seat_v1_add_listener(seat->ls, &ls_seat_listener, seat);
 	wl_list_insert(&wm.seats, &seat->link);
 }
+static void manage_seat_op(struct Seat *seat) {
+	switch (seat->op) {
+	case SEAT_OP_NONE:
+		break;
+	case SEAT_OP_MOVE:
+		if (seat->op_release) {
+			river_seat_v1_op_end(seat->obj);
+			seat->op = SEAT_OP_NONE;
+			seat->op_window = NULL;
+			break;
+		}
+		break;
+	case SEAT_OP_RESIZE:
+		if (seat->op_release) {
+			river_window_v1_inform_resize_end(seat->op_window->obj);
+			river_seat_v1_op_end(seat->obj);
+			seat->op = SEAT_OP_NONE;
+			seat->op_window = NULL;
+			break;
+		}
+		int32_t width = seat->op_start_width;
+		int32_t height = seat->op_start_height;
+		if ((seat->op_edges & RIVER_WINDOW_V1_EDGES_LEFT) != 0) {
+			width -= seat->op_dx;
+		}
+		if ((seat->op_edges & RIVER_WINDOW_V1_EDGES_RIGHT) != 0) {
+			width += seat->op_dx;
+		}
+		if ((seat->op_edges & RIVER_WINDOW_V1_EDGES_TOP) != 0) {
+			height -= seat->op_dy;
+		}
+		if ((seat->op_edges & RIVER_WINDOW_V1_EDGES_BOTTOM) != 0) {
+			height += seat->op_dy;
+		}
+		if (width < 1)
+			width = 1;
+		if (height < 1)
+			height = 1;
+		river_window_v1_propose_dimensions(
+				seat->op_window->obj, width, height);
+		seat->op_window->float_layout.width = width;
+		seat->op_window->float_layout.height = height;
+		break;
+	}
+	seat->op_release = false;
+}
 
 static void wm_handle_window(void *data, struct river_window_manager_v1 *obj, struct river_window_v1 *river_window) {
 	struct Window *window = calloc(1, sizeof(struct Window));
 	window->obj = river_window;
 	window->node = river_window_v1_get_node(window->obj);
 	window->set_capabilities = true;
+	window->float_layout.x = 100;
+	window->float_layout.y = 100;
+	window->float_layout.width = 800;
+	window->float_layout.height = 600;
 
 	place_window(window);
 	river_window_v1_add_listener(window->obj, &river_window_listener, window);
@@ -367,7 +434,9 @@ static void wm_handle_manage_start(void *data, struct river_window_manager_v1 *o
 	wl_list_for_each(seat, &wm.seats, link) {
 		manage_xkb_bindings(seat);
 		manage_seat_focus(seat);
+		manage_seat_op(seat);
 	}
+
 	river_window_manager_v1_manage_finish(window_manager_v1);
 }
 
@@ -381,8 +450,10 @@ static void wm_handle_render_start(void *data, struct river_window_manager_v1 *w
 		render_space(space);
 
 	struct Seat *seat;
-	wl_list_for_each(seat, &wm.seats, link)
+	wl_list_for_each(seat, &wm.seats, link) {
+		render_pointer_op(seat);
 		render_seat_focus(seat);
+	}
 
 	river_window_manager_v1_render_finish(window_manager_v1);
 }

--- a/jrwm.h
+++ b/jrwm.h
@@ -29,6 +29,11 @@
 struct Rect {
 	int32_t x, y, width, height;
 };
+enum SeatOp {
+	SEAT_OP_NONE,
+	SEAT_OP_MOVE,
+	SEAT_OP_RESIZE,
+};
 
 // A Space represents a collection of Windows on an Output with a layout.
 // Space is the "clearing-house" type for the WM; there MUST be at least one
@@ -65,6 +70,7 @@ struct Window {
 	bool maximized;  // The window has been inform_maximized
 	bool fullscreen; // The window is fullscreen
 	bool fake_fullscreen; // The window acts as if fullscreen
+	bool floating;
 
 	// Deferred tasks for the manage sequence
 	bool set_capabilities;  // window_v1.set_capabilities
@@ -75,8 +81,13 @@ struct Window {
 
 	// Information for the render sequence
 	struct Rect layout;
+	struct Rect float_layout;
 
 	struct Space *space;    // Non-null
+
+	struct Seat *pointer_move_requested;
+	struct Seat *pointer_resize_requested;
+	uint32_t pointer_resize_requested_edges;
 };
 
 // A Seat is a collection of input devices.
@@ -92,6 +103,16 @@ struct Seat {
 
 	bool ls_focused;        // Layer shell surface has focus
 	struct Space *focused;  // Non-null
+
+	enum SeatOp op;
+	// For SEAT_OP_MOVE and SEAT_OP_RESIZE
+	struct Window *op_window;
+	int32_t op_start_x, op_start_y;
+	int32_t op_dx, op_dy;
+	bool op_release;
+	// For SEAT_OP_RESIZE only
+	int32_t op_start_width, op_start_height;
+	uint32_t op_edges;
 };
 
 // Args and Binddefs are used to configure XkbBindings
@@ -152,6 +173,7 @@ extern void manage_space(struct Space *);
 extern void manage_seat_focus(struct Seat *);
 
 // Called during the render sequence
+extern void render_pointer_op(struct Seat *);
 extern void render_space(struct Space *);
 extern void render_seat_focus(struct Seat *);
 
@@ -165,6 +187,7 @@ extern void binding_close(struct Seat *, union Arg);
 
 extern void binding_toggle_fake_fullscreen(struct Seat *, union Arg);
 extern void binding_toggle_fullscreen(struct Seat *, union Arg);
+extern void binding_toggle_floating(struct Seat *, union Arg);
 extern void binding_toggle_monocle(struct Seat *, union Arg);
 
 extern void binding_change_split_ratio(struct Seat *, union Arg);

--- a/layout.c
+++ b/layout.c
@@ -191,11 +191,11 @@ extern void tiled_layout(struct Space *space, struct Rect bounds) {
 	int count = 0, w = 0, rightwidth = bounds.width, rightheight = bounds.height;
 	struct Window *window;
 	wl_list_for_each(window, &wm.windows, link) {
-		if (window->space == space)
+		if (window->space == space && !window->floating)
 			count++;
 	}
 	wl_list_for_each(window, &wm.windows, link) {
-		if (window->space != space)
+		if (window->space != space || window->floating)
 			continue;
 		if (window->maximized) {
 			river_window_v1_inform_unmaximized(window->obj);
@@ -222,6 +222,31 @@ extern void tiled_layout(struct Space *space, struct Rect bounds) {
 	}
 }
 
+static void seat_pointer_move(struct Seat *seat, struct Window *window) {
+	// seat_focus(seat, window);
+	river_seat_v1_op_start_pointer(seat->obj);
+	seat->op = SEAT_OP_MOVE;
+	seat->op_window = window;
+	seat->op_start_x = window->float_layout.x;
+	seat->op_start_y = window->float_layout.y;
+	seat->op_dx = 0;
+	seat->op_dy = 0;
+}
+
+static void seat_pointer_resize(struct Seat *seat, struct Window *window, uint32_t edges) {
+	// seat_focus(seat, window);
+	river_window_v1_inform_resize_start(window->obj);
+	river_seat_v1_op_start_pointer(seat->obj);
+	seat->op = SEAT_OP_RESIZE;
+	seat->op_window = window;
+	seat->op_edges = edges;
+	seat->op_start_x = window->float_layout.x;
+	seat->op_start_y = window->float_layout.y;
+	seat->op_start_width = window->float_layout.width;
+	seat->op_start_height = window->float_layout.height;
+	seat->op_dx = 0;
+	seat->op_dy = 0;
+}
 
 // Manage sequence/render sequence functions
 
@@ -257,6 +282,15 @@ extern void manage_window_deferred(struct Window *window) {
 	if (window->exit_fullscreen) {
 		unfullscreen_window(window);
 		window->exit_fullscreen = false;
+	}
+	if (window->pointer_move_requested != NULL) {
+		seat_pointer_move(window->pointer_move_requested, window);
+		window->pointer_move_requested = NULL;
+	}
+	if (window->pointer_resize_requested != NULL) {
+		seat_pointer_resize(window->pointer_resize_requested, window,
+				window->pointer_resize_requested_edges);
+		window->pointer_resize_requested = NULL;
 	}
 }
 
@@ -314,11 +348,21 @@ extern void manage_space(struct Space *space) {
 			continue;
 		if (window->fullscreen && window->space->focused != window)
 			unfullscreen_window(window);
-		river_window_v1_use_ssd(window->obj);
-		river_window_v1_set_tiled(window->obj, 15);
-		river_window_v1_propose_dimensions(window->obj,
-				window->layout.width,
-				window->layout.height);
+		if (window->floating) {
+			river_window_v1_use_csd(window->obj);
+			river_node_v1_set_position(window->node,
+					window->float_layout.x, window->float_layout.y);
+			river_window_v1_propose_dimensions(window->obj,
+					window->float_layout.width,
+					window->float_layout.height);
+		}
+		else {
+			river_window_v1_use_ssd(window->obj);
+			river_window_v1_set_tiled(window->obj, 15);
+			river_window_v1_propose_dimensions(window->obj,
+					window->layout.width,
+					window->layout.height);
+		}
 	}
 }
 
@@ -333,12 +377,42 @@ extern void render_space(struct Space *space) {
 		if (window->space != space || !valid_rect(window->layout))
 			continue;
 		river_window_v1_show(window->obj);
-		river_node_v1_set_position(window->node,
-				window->layout.x, window->layout.y);
+		if (!window->floating)
+			river_node_v1_set_position(window->node,
+					window->layout.x, window->layout.y);
 		if (space->layout == monocle_layout)
 			render_border(window, monocle_borderpx, border_color);
 		else
 			render_border(window, tiled_borderpx, border_color);
+	}
+}
+
+extern void render_pointer_op(struct Seat *seat) {
+	int32_t x;
+	int32_t y;
+	switch (seat->op) {
+	case SEAT_OP_NONE:
+		break;
+	case SEAT_OP_MOVE:
+		x = seat->op_start_x + seat->op_dx;
+		y = seat->op_start_y + seat->op_dy;
+		river_node_v1_set_position(seat->op_window->node, x, y);
+		seat->op_window->float_layout.x = x;
+		seat->op_window->float_layout.y = y;
+		break;
+	case SEAT_OP_RESIZE:
+		x = seat->op_start_x;
+		y = seat->op_start_y;
+		if ((seat->op_edges & RIVER_WINDOW_V1_EDGES_LEFT) != 0) {
+			x += seat->op_start_width - seat->op_window->float_layout.width;
+		}
+		if ((seat->op_edges & RIVER_WINDOW_V1_EDGES_TOP) != 0) {
+			y += seat->op_start_height - seat->op_window->float_layout.height;
+		}
+		river_node_v1_set_position(seat->op_window->node, x, y);
+		seat->op_window->float_layout.x = x;
+		seat->op_window->float_layout.y = y;
+		break;
 	}
 }
 


### PR DESCRIPTION
This is bad and incomplete, but I thought it might be good to start somewhere, so tried to keep it small. Love to get your opinions.

Problems I'm aware of:
* Probably doesn't account for multiple outputs, I can't test easily.
* Maximizing floating windows is borked.
* I think floats should always remain above tiled windows (?)
* I think focus follows mouse should change focus but not raise above other floats until a further interaction (?)
* No pointer binds added for mod+mouse dragging.
* Focus issues I've whined about before.
* Might be good to apply bounds to stop windows becoming completely unreachable.
* There might be some small pixel errors due to border width not being taken into account.
* Might be issues when closing windows mid resize/move.

Probably more...

Apologies if it's just a waste of your time, you already have something you're working on, etc etc.