### PR TITLE
Allow multiple windows in the left "main" window

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -136,6 +136,14 @@ static void change_split_ratio(struct Space *space, float change) {
 	space->tiled_splitratio = target;
 }
 
+static void change_main_depth(struct Space *space, int change) {
+	// Allow the main stack depth to be set to zero, in which
+	// case all windows in the space will be stacked horizontally.
+	//
+	// This matches the behavior of dwm.
+	space->tiled_max_depth = MAX(space->tiled_max_depth + change, 0);
+}
+
 
 // Binding function definitions
 // None of these functions run during a manage or render sequence
@@ -194,6 +202,10 @@ extern void binding_toggle_monocle(struct Seat *seat, union Arg arg) {
 
 extern void binding_change_split_ratio(struct Seat *seat, union Arg arg) {
 	change_split_ratio(seat->focused, arg.f);
+}
+
+extern void binding_change_main_depth(struct Seat *seat, union Arg arg) {
+	change_main_depth(seat->focused, arg.i);
 }
 
 extern void binding_focus_next(struct Seat *seat, union Arg arg) {

--- a/config.c
+++ b/config.c
@@ -46,6 +46,7 @@ int tiled_borderpx   = 2;
 
 int tiled_margin         = -2;	// Space between windows
 int tiled_output_padding =  0;	// Space around windows
+int tiled_main_size      =  1;	// Default amount of windows on "main" stack
 float tiled_splitratio   =  0.52;
 
 
@@ -80,8 +81,12 @@ struct Binddef binds[] = {
 	{super|shift, XKB_KEY_j, binding_move_next,  {0}},
 	{super,       XKB_KEY_k, binding_focus_prev, {0}},
 	{super|shift, XKB_KEY_k, binding_move_prev,  {0}},
+
+	// Bindings for modifying the tiling layout behavior
 	{super|alt,   XKB_KEY_h, binding_change_split_ratio, {.f = -0.1}},
 	{super|alt,   XKB_KEY_l, binding_change_split_ratio, {.f =  0.1}},
+	{super|alt,   XKB_KEY_i, binding_change_main_depth,  {.i = +1}},
+	{super|alt,   XKB_KEY_d, binding_change_main_depth,  {.i = -1}},
 
 	// Bindings for relative motion between spaces
 	{super,       XKB_KEY_h, binding_activate_prev_busy_space, {0}},

--- a/jrwm.c
+++ b/jrwm.c
@@ -445,6 +445,7 @@ static void wm_init(void) {
 	for (i = 0; i < sp; i++) {
 		struct Space *space = create_space();
 		space->is_static = (i < static_spaces);
+		space->tiled_max_depth = tiled_main_size;
 		wl_list_insert(&wm.spaces, &space->link);
 	}
 }

--- a/jrwm.h
+++ b/jrwm.h
@@ -24,6 +24,12 @@
 #include <river-xkb-bindings-v1.h>
 
 
+// Utility macros
+
+#define MAX(A, B) ((A) > (B) ? (A) : (B))
+#define MIN(A, B) ((A) < (B) ? (A) : (B))
+
+
 // Types
 
 struct Rect {
@@ -41,6 +47,7 @@ struct Space {
 
 	bool is_static;         // Static spaces are never removed
 	float tiled_splitratio;
+	int tiled_max_depth;
 
 	void (*layout)(struct Space *space, struct Rect bounds);
 };
@@ -168,6 +175,7 @@ extern void binding_toggle_fullscreen(struct Seat *, union Arg);
 extern void binding_toggle_monocle(struct Seat *, union Arg);
 
 extern void binding_change_split_ratio(struct Seat *, union Arg);
+extern void binding_change_main_depth(struct Seat *, union Arg);
 
 extern void binding_focus_next(struct Seat *, union Arg);
 extern void binding_focus_prev(struct Seat *, union Arg);
@@ -213,6 +221,7 @@ extern int monocle_borderpx;
 extern int tiled_borderpx;
 extern int tiled_margin;
 extern int tiled_output_padding;
+extern int tiled_main_size;
 extern float tiled_splitratio;
 
 extern bool focus_follows_pointer;

--- a/layout.c
+++ b/layout.c
@@ -188,12 +188,14 @@ extern void monocle_layout(struct Space *space, struct Rect bounds) {
 
 extern void tiled_layout(struct Space *space, struct Rect bounds) {
 	subtract_border(&bounds, tiled_output_padding);
-	int count = 0, w = 0, rightwidth = bounds.width, rightheight = bounds.height;
+	int count = 0, w = 0, rightwidth = bounds.width, stackheight = bounds.height;
 	struct Window *window;
 	wl_list_for_each(window, &wm.windows, link) {
 		if (window->space == space)
 			count++;
 	}
+	int max_main_depth = space->tiled_max_depth;
+	int cur_main_depth = MIN(count, max_main_depth);
 	wl_list_for_each(window, &wm.windows, link) {
 		if (window->space != space)
 			continue;
@@ -201,21 +203,29 @@ extern void tiled_layout(struct Space *space, struct Rect bounds) {
 			river_window_v1_inform_unmaximized(window->obj);
 			window->maximized = false;
 		}
-		if (count == 1 || w == 0) {
-			// Left side "main" window
+		if (count == 1 || w < max_main_depth) {
+			// Left side "main" windows
 			window->layout = bounds;
-			if (count > 1)
+			if (cur_main_depth > 1) {
+				window->layout.height = stackheight / (cur_main_depth - w);
+				window->layout.y = bounds.y + bounds.height - stackheight;
+				stackheight -= window->layout.height + tiled_margin;
+			}
+			if (count > max_main_depth)
 				window->layout.width *= space->tiled_splitratio;
 
-			rightwidth -= window->layout.width + tiled_margin;
+			if (w == max_main_depth - 1) { /* last window on "main" stack? */
+				rightwidth -= window->layout.width + tiled_margin;
+				stackheight = bounds.height;
+			}
 		} else {
 			// Right side "stacked" windows
 			window->layout.x = bounds.x + bounds.width - rightwidth;
-			window->layout.y = bounds.y + bounds.height - rightheight;
+			window->layout.y = bounds.y + bounds.height - stackheight;
 			window->layout.width = rightwidth;
-			window->layout.height = rightheight / (count - w);
+			window->layout.height = stackheight / (count - w);
 
-			rightheight -= window->layout.height + tiled_margin;
+			stackheight -= window->layout.height + tiled_margin;
 		}
 		subtract_border(&window->layout, tiled_borderpx);
 		w++;

--- a/layout.c
+++ b/layout.c
@@ -206,27 +206,24 @@ extern void tiled_layout(struct Space *space, struct Rect bounds) {
 		if (count == 1 || w < max_main_depth) {
 			// Left side "main" windows
 			window->layout = bounds;
-			if (cur_main_depth > 1) {
-				window->layout.height = stackheight / (cur_main_depth - w);
-				window->layout.y = bounds.y + bounds.height - stackheight;
-				stackheight -= window->layout.height + tiled_margin;
-			}
+			window->layout.height = stackheight / (cur_main_depth - w);
 			if (count > max_main_depth)
 				window->layout.width *= space->tiled_splitratio;
-
-			if (w == max_main_depth - 1) { /* last window on "main" stack? */
-				rightwidth -= window->layout.width + tiled_margin;
-				stackheight = bounds.height;
-			}
 		} else {
 			// Right side "stacked" windows
 			window->layout.x = bounds.x + bounds.width - rightwidth;
-			window->layout.y = bounds.y + bounds.height - stackheight;
 			window->layout.width = rightwidth;
 			window->layout.height = stackheight / (count - w);
-
-			stackheight -= window->layout.height + tiled_margin;
 		}
+
+		window->layout.y = bounds.y + bounds.height - stackheight;
+		stackheight -= window->layout.height + tiled_margin;
+
+		if (w == max_main_depth - 1) { /* last window on "main" stack? */
+			rightwidth -= window->layout.width + tiled_margin;
+			stackheight = bounds.height;
+		}
+
 		subtract_border(&window->layout, tiled_borderpx);
 		w++;
 	}


### PR DESCRIPTION
First of, thanks for creating jrwm, it's the first river 0.4.X-based WM that actually appeals to me! During my testing I discovered that jrwm is missing a central feature from river-classic/dwm that I rely on quite heavily: The ability of the left window to also behave as a stack in the tiling layout.

The implementation added here is akin to the one provided by dwm and thus backwards compatible with the previous jrwm behavior. By default, only a single window is tracked on the left "main" window. However, now it is possible to increment/decrement the amount of windows tracked on the left using two dedicated key bindings:

1. `super+alt+i`: Increments the size of the main stack
2. `super+alt+d`: Decrements the size of the main stack

I haven't used this extensively so far (I just discovered jrwm today), but I am currently unaware of bugs. Since I believe this to be a tweak “to existing behavior to more closely match other WMs”, I thought that you might be interested in this feature (no hard feelings if not) :)