### PR TITLE
Treat popups and dialogs as floating windows

### DIFF
--- a/jrwm.c
+++ b/jrwm.c
@@ -186,6 +186,7 @@ static void window_handle_parent(void *data, struct river_window_v1 *obj, struct
 	struct Window *window = data;
 	if (parent != NULL) {
 		window->floating = true;
+		center_window(window);
 	}
 }
 
@@ -202,8 +203,10 @@ static void window_handle_dimensions_hint(void *data, struct river_window_v1 *ob
 		max_height == min_height;
 	bool is_small = max_width > 0 && max_height > 0 &&
 		max_width < 600 && max_height < 400;
-	if (is_fixed || is_small)
+	if (is_fixed || is_small) {
 		window->floating = true;
+		center_window(window);
+	}
 }
 
 static void window_handle_dimensions(void *data, struct river_window_v1 *obj, int32_t width, int32_t height) {

--- a/jrwm.c
+++ b/jrwm.c
@@ -179,6 +179,33 @@ static void window_handle_exit_fullscreen_requested(void *data, struct river_win
 	window->exit_fullscreen = true;
 }
 
+static void window_handle_parent(void *data, struct river_window_v1 *obj, struct river_window_v1 *parent) {
+	// From river-window-management-v1: “A surface with a parent set
+	// might be a dialog, file picker, or similar for the parent
+	// window.” Therefore, we treat such windows as floating.
+	struct Window *window = data;
+	if (parent != NULL) {
+		window->floating = true;
+	}
+}
+
+static void window_handle_dimensions_hint(void *data, struct river_window_v1 *obj, int32_t min_width, int32_t min_height, int32_t max_width, int32_t max_height) {
+	// Treat windows with a fixed size or windows with a very small dimension
+	// as dialog/popup windows. This is necessary because not all dialogs have
+	// a parent window set (see window_handle_parent).
+	//
+	// This logic was originally taken from the river-based kwm window manager.
+	// See <https://github.com/kewuaa/kwm/blob/v0.3.0/src/kwm/window.zig#L1087-L1095>.
+	struct Window *window = data;
+	bool is_fixed = max_width > 0 && max_height > 0 &&
+		max_width == min_width &&
+		max_height == min_height;
+	bool is_small = max_width > 0 && max_height > 0 &&
+		max_width < 600 && max_height < 400;
+	if (is_fixed || is_small)
+		window->floating = true;
+}
+
 static void window_handle_dimensions(void *data, struct river_window_v1 *obj, int32_t width, int32_t height) {
 	struct Window *window = data;
 	if (width < window->layout.width)
@@ -205,10 +232,8 @@ static void window_handle_unmaximize_requested(void *data, struct river_window_v
 // Ignored events
 static void window_handle_app_id(void *data, struct river_window_v1 *obj, const char *app_id) {}
 static void window_handle_decoration_hint(void *data, struct river_window_v1 *obj, uint32_t hint) {}
-static void window_handle_dimensions_hint(void *data, struct river_window_v1 *obj, int32_t min_width, int32_t min_height, int32_t max_width, int32_t max_height) {}
 static void window_handle_identifier(void *data, struct river_window_v1 *obj, const char *indentifier) {}
 static void window_handle_minimize_requested(void *data, struct river_window_v1 *obj) {}
-static void window_handle_parent(void *data, struct river_window_v1 *obj, struct river_window_v1 *parent) {}
 static void window_handle_pointer_move_requested(void *data, struct river_window_v1 *obj, struct river_seat_v1 *river_seat) {}
 static void window_handle_pointer_resize_requested(void *data, struct river_window_v1 *obj, struct river_seat_v1 *river_seat, uint32_t edges) {}
 static void window_handle_presentation_hint(void *data, struct river_window_v1 *obj, uint32_t hint) {}

--- a/jrwm.h
+++ b/jrwm.h
@@ -74,6 +74,15 @@ struct Window {
 	bool fake_fullscreen; // The window acts as if fullscreen
 	bool floating; // The window is floating
 
+	// In river-window-management-v1, dialog windows are intended to be detected
+	// through the river_window_v1.parent event (i.e., they have a parent window).
+	// However, many clients do not emit this event. Therefore, we further use a
+	// heuristic for detecting these windows based on the maximum width/height
+	// communicated through the river_window_v1.dimensions_hint. Sadly, this hint
+	// is only send after window is rendered, therefore we hide them on the first
+	// frame. Born is used to indicate if the window was rendered for >1 frames.
+	bool born;
+
 	// Deferred tasks for the manage sequence
 	bool set_capabilities;  // window_v1.set_capabilities
 	bool close;             // window_v1.close

--- a/jrwm.h
+++ b/jrwm.h
@@ -72,6 +72,7 @@ struct Window {
 	bool maximized;  // The window has been inform_maximized
 	bool fullscreen; // The window is fullscreen
 	bool fake_fullscreen; // The window acts as if fullscreen
+	bool floating; // The window is floating
 
 	// Deferred tasks for the manage sequence
 	bool set_capabilities;  // window_v1.set_capabilities

--- a/jrwm.h
+++ b/jrwm.h
@@ -148,6 +148,7 @@ extern void monocle_layout(struct Space *, struct Rect);
 // Called on creation of objects to manage internal pointers
 extern void place_output(struct Output *);
 extern void place_window(struct Window *);
+extern void center_window(struct Window *);
 extern void place_seat(struct Seat *);
 
 // Called on deletion of objects

--- a/layout.c
+++ b/layout.c
@@ -191,13 +191,13 @@ extern void tiled_layout(struct Space *space, struct Rect bounds) {
 	int count = 0, w = 0, rightwidth = bounds.width, stackheight = bounds.height;
 	struct Window *window;
 	wl_list_for_each(window, &wm.windows, link) {
-		if (window->space == space)
+		if (window->space == space && !window->floating)
 			count++;
 	}
 	int max_main_depth = space->tiled_max_depth;
 	int cur_main_depth = MIN(count, max_main_depth);
 	wl_list_for_each(window, &wm.windows, link) {
-		if (window->space != space)
+		if (window->space != space || window->floating)
 			continue;
 		if (window->maximized) {
 			river_window_v1_inform_unmaximized(window->obj);
@@ -323,7 +323,8 @@ extern void manage_space(struct Space *space) {
 		if (window->fullscreen && window->space->focused != window)
 			unfullscreen_window(window);
 		river_window_v1_use_ssd(window->obj);
-		river_window_v1_set_tiled(window->obj, 15);
+		river_window_v1_set_tiled(window->obj,
+				(window->floating) ? 0 : 15);
 		river_window_v1_propose_dimensions(window->obj,
 				window->layout.width,
 				window->layout.height);
@@ -340,6 +341,10 @@ extern void render_space(struct Space *space) {
 	wl_list_for_each(window, &wm.windows, link) {
 		if (window->space != space || !valid_rect(window->layout))
 			continue;
+		if (window->floating)
+			river_node_v1_place_top(window->node);
+		else if (space->focused && window != space->focused)
+			river_node_v1_place_bottom(window->node);
 		river_window_v1_show(window->obj);
 		river_node_v1_set_position(window->node,
 				window->layout.x, window->layout.y);
@@ -354,7 +359,6 @@ extern void render_seat_focus(struct Seat *seat) {
 	struct Window *window = seat->focused->focused;
 	if (window == NULL || seat->ls_focused)
 		return;
-	river_node_v1_place_top(window->node);
 	if (seat->focused->layout == monocle_layout)
 		render_border(window, monocle_borderpx, focused_color);
 	else

--- a/layout.c
+++ b/layout.c
@@ -202,13 +202,13 @@ extern void tiled_layout(struct Space *space, struct Rect bounds) {
 	int count = 0, w = 0, rightwidth = bounds.width, stackheight = bounds.height;
 	struct Window *window;
 	wl_list_for_each(window, &wm.windows, link) {
-		if (window->space == space && !window->floating)
+		if (window->space == space && !window->floating && window->born)
 			count++;
 	}
 	int max_main_depth = space->tiled_max_depth;
 	int cur_main_depth = MIN(count, max_main_depth);
 	wl_list_for_each(window, &wm.windows, link) {
-		if (window->space != space || window->floating)
+		if (window->space != space || window->floating || !window->born)
 			continue;
 		if (window->maximized) {
 			river_window_v1_inform_unmaximized(window->obj);
@@ -350,6 +350,13 @@ extern void render_space(struct Space *space) {
 
 	struct Window *window;
 	wl_list_for_each(window, &wm.windows, link) {
+		// Hide window on the first frame, see the `born` member comment.
+		if (!window->born) {
+			window->born = true;
+			place_window(window);
+			continue;
+		}
+
 		if (window->space != space || !valid_rect(window->layout))
 			continue;
 		if (window->floating)

--- a/layout.c
+++ b/layout.c
@@ -124,6 +124,17 @@ extern void place_window(struct Window *window) {
 	}
 }
 
+// Center window on its output, no-op if it doesn't have an active output
+extern void center_window(struct Window *window) {
+	struct Output *output = active_on_output(window->space);
+	if (output == NULL)
+		return;
+
+	struct Rect bounds = output->windowed;
+	window->layout.x = (bounds.width - window->layout.width)/2;
+	window->layout.y = (bounds.height - window->layout.height)/2;
+}
+
 // Replace this Window with any other where necessary
 extern void replace_window(struct Window *window) {
 	struct Seat *seat;


### PR DESCRIPTION
I use a lot of software that spawns dialogs, for example my password manager constantly spawns pinentry-dialogs. These are currently rendered as tiling windows in the `tiling_layout` function. To fix that, this adds some preliminary support for floating windows (see #16). Contrary to the prior attempt from PR #13, the focus of this PR is on properly handling dialog and popup windows created by clients, not on converting existing windows from a tiling to a floating layout. As such, the PR does currently also not implement moving or resizing of floating windows.

Instead, the PR focuses on fixing the rendering of dialog windows in the tiling layout. With this patch applied, dialog and popups do not take up an entire tile in the tiling layout and are rendered on top.

Detecting popups and dialogs is a bit challenging. The `river-window-management-v1` protocol mentions detection through the fact that [such windows have a parent set](https://isaacfreund.com/docs/wayland/river-window-management-v1/#river_window_v1.parent). However, unfortunately, many dialog-like windows don't. Therefore, this commit also includes a heuristic from [kwm](https://github.com/kewuaa/kwm) that detects such windows based on the [dimension hint](https://isaacfreund.com/docs/wayland/river-window-management-v1/#river_window_v1.dimensions_hint).

Without this patch:

<img width="3840" height="2160" alt="jrwm-floating-old" src="https://github.com/user-attachments/assets/79563e46-eaae-4695-a9aa-068259ddb14f" />

With this patch applied:

<img width="3840" height="2160" alt="jrwm-floating-new" src="https://github.com/user-attachments/assets/8b10cbe5-e03a-4394-a522-a9a6e087e75d" />

---

**Remaining To-Dos:**

* [x] Floating windows should *always* be placed over the tiling ones.
* [x] The layout code is already run before the `dimensions_hint` is handled, briefly causing the window to be rendered as in the first screenshot. Not sure why that happens yet, let me know if you have an idea.

Contrary to #16, I don't want to implement `toggle_float`, resizing or moving of floating windows in this PR. I just want to fix the handling of dialog windows, which—in my view—is a prerequisite for the former anyhow.